### PR TITLE
Update gimousehelper.cpp

### DIFF
--- a/core/src/view/gimousehelper.cpp
+++ b/core/src/view/gimousehelper.cpp
@@ -34,6 +34,8 @@ bool GiMouseHelper::onMouseUp(float x, float y)
             kGiGestureBegan, x, y);
     }
 
+    _ldown = false; _rdown = false;
+
     return ret;
 }
 


### PR DESCRIPTION
在Windows平台，点击程序标题栏，放大缩小程序的时候，落入视图会在重新绘制一个。修改后就不会了。